### PR TITLE
basic adaptations to work on FLI cluster as well

### DIFF
--- a/modules/clair3.nf
+++ b/modules/clair3.nf
@@ -22,9 +22,11 @@ time { 36.hour * task.attempt }
         script :
         if( "${Technology}" == 'ONT')
                 """
+                source activate clair3
                 if [[ ${Kit} -eq 1041 ]] 
                 then
-                        ONT_model_path='models/r1041_e82_400bps_sup_g615'
+                        # ONT_model_path='models/r1041_e82_400bps_sup_g615'
+                        ONT_model_path='models/r1041_e82_400bps_sup_v420'
                 elif [[ ${Kit} -eq 1040 ]] 
                 then
                         ONT_model_path='models/r104_e81_sup_g5015'

--- a/modules/deepvariant.nf
+++ b/modules/deepvariant.nf
@@ -23,6 +23,7 @@ time { 36.hour * task.attempt }
         if( "${Technology}" == 'ONT' && "${Kit}" >= '1041')
                 """
                 deepvariant_flag='ONT_R104'
+                # [ ! -z \${TMPDIR} ] && nodeDir=`mktemp -d \${TMPDIR}/DEEPVARXXXX` || 
                 nodeDir=`mktemp -d /tmp/DEEPVARXXXX`
                 echo \$nodeDir
                 zcat ${genome} > \$nodeDir/ARS-UCD1.2_Btau5.0.1Y.fa

--- a/modules/filtlong.nf
+++ b/modules/filtlong.nf
@@ -70,7 +70,10 @@ maxRetries 3
                 """
                 cat ${FASTQ_LR_Dir}/*.fastq.gz > tmp.fastq.gz
 
-                porechop_abi -abi -i tmp.fastq.gz -o ${SampleID_LR}_PREQC.fastq.gz
+                porechop_abi -abi -i tmp.fastq.gz -o ${SampleID_LR}_PREQC.fastq.gz # -tmp
+
+                gunzip -c ${SampleID_LR}_PREQC.fastq.gz  | awk 'BEGIN{FS="\t";OFS=FS;n=1;old=""};\$1!~/^@/{print;next};\$1==old{\$1 = \$1 "_" n;n=n+1;print;next};{old=\$1;n=1;print;next}' > ${SampleID_LR}_PREQC.fastq
+                gzip -f ${SampleID_LR}_PREQC.fastq
 
                 NanoPlot -t $task.cpus --fastq ${SampleID_LR}_PREQC.fastq.gz --outdir ${SampleID_LR}_PREQC_NanoPlot --loglength --plots dot
 

--- a/modules/longshot.nf
+++ b/modules/longshot.nf
@@ -1,7 +1,7 @@
 // SNVs calling settings 
 
 process LONGSHOT {
-queue 'batch'
+// queue 'batch' // problems in slurm, as transferred to partition argument --> check
 time { 8.hour * task.attempt }
 
         //scratch true

--- a/modules/nanofilt.nf
+++ b/modules/nanofilt.nf
@@ -1,5 +1,5 @@
 process NANOFILT {
-queue 'batch'
+// queue 'batch' // problems in slurm, as transferred to partition argument --> check 
 cpus = 24
 memory { 128.GB * task.attempt }
 time { 24.hour * task.attempt } //Very long if you doing short-read polish

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,6 +7,7 @@ manifest {
 }
 
 nextflow.enable.configProcessNamesValidation = false
+params.Source_Dir           = '/home/johannes.geibel/data/testNFExplo/results' //####!warning needed!!!!!!
 
 /////////////////////
 // BASE PARAMETERS //
@@ -46,6 +47,7 @@ profiles {
         podman.enabled         = false
         shifter.enabled        = false
         charliecloud.enabled   = false
+        singularity.runOptions = "--bind \${TMPDIR}:/tmp --bind \${TMPDIR} --bind ${params.Source_Dir}"
     }
     podman {
         podman.enabled         = true
@@ -74,6 +76,9 @@ profiles {
     }
     agvic { 
         includeConfig 'conf/agvic.config'
+    }
+    slurm { 
+        process.executor = 'slurm'
     }
 }
 
@@ -162,7 +167,7 @@ params.enable_filtlong      = true
 // SNP calling // Multiple allow
 params.enable_clair3        = true
 params.enable_pepper        = true 
-params.enable_longshot      = true // Currently supporting, cannot calling INDEL, suitable for > 30X coverage
+params.enable_longshot      = false // Currently supporting, cannot calling INDEL, suitable for > 30X coverage // container misses /bin/bash
 params.enable_deepvar       = true
 
 // SVs calling // Multiple allow
@@ -183,11 +188,11 @@ params.GenomeDir              = 'asset/genome_compact'
 /////////////////////////////////
 
 // Output Dir # Have to address this one, the rest should be automatically resolved :) 
-params.Source_Dir           = '/group/dairy/Tuan/Recessive_lethal/Nextflow/results'
+params.Source_Dir           = '/home/johannes.geibel/data/testNFExplo/results' //####!warning needed!!!!!!
 
 // SNVs calling settings 
 // Clair3
-params.clair3_model_path        = 'asset/models'
+params.clair3_model_path        = '/data/users/johannes.geibel/testNFExplo/asset/models'
 
 /// DO NOT EDIT :) ///
 params.Report_Dir = "${params.Source_Dir}/Log"

--- a/setup.nf
+++ b/setup.nf
@@ -61,7 +61,9 @@ process download_clair3_model {
     script:
     """
     wget http://www.bio8.cs.hku.hk/clair3/clair3_models/clair3_models.tar.gz 
+    wget http://www.bio8.cs.hku.hk/clair3/clair3_models/r1041_e82_400bps_sup_v420.tar.gz
     tar -zxvf clair3_models.tar.gz 
+    tar -zxvf r1041_e82_400bps_sup_v420.tar.gz
     """
 }
 


### PR DESCRIPTION
These changes were necessary to make the pipeline work on the FLI cluster. They included some adaptations to work on Slurm with Singularity containers (exporting of certain file systems and TMPDIR paths, queue naming) and setting file paths. Additionally, there remain some further questions before merging the branch:
- how to include additional clair 3 models in the best way 
- Porechop_abi caused an error due to not renaming splitted reads correctly --> could be a problem of having methylation tags in the fastq. Still need to check and potentially open an issue for porechop_abi
- mosdepth curretly writes output to "Log" --> should write to "QC" instead?
- It would be helpful to add a final rule for [multiqc](https://multiqc.info/) to summarize QC results across samples
- setting of paths should be at the beginning of the "nextflow.config" file, as needs likely to be changed
- pipeline contains "meta/metadata_LR.csv", which needed to be renamed to "meta/LR_metadata.csv" --> should come from a parameter set in config instead
- for the BOV_LRC, certain participants might have their raw data as u.bam format --> should we provide a script to do bam to fastq transvertion, or include a process in pipeline?
